### PR TITLE
Oauth attempt1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ secrets.py
 /cassettes
 .coverage
 public_officials/static/images/profiles
+/penv

--- a/public_officials/templates/public-officials/about.html
+++ b/public_officials/templates/public-officials/about.html
@@ -19,6 +19,12 @@
               <li><a href="{% url 'senator_index' %}">Senators</a></li>
               <li><a href="{% url 'representative_index' %}">Representatives</a></li>
               <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/bills/index.html
+++ b/public_officials/templates/public-officials/bills/index.html
@@ -16,10 +16,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
-            <li><a href="{% url 'senator_index' %}">Senators</a></li>
-            <li><a href="{% url 'representative_index' %}">Representatives</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/detail.html
+++ b/public_officials/templates/public-officials/detail.html
@@ -20,10 +20,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
-            <li><a href="{% url 'senator_index' %}">Senators</a></li>
-            <li><a href="{% url 'representative_index' %}">Representatives</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/home.html
+++ b/public_officials/templates/public-officials/home.html
@@ -25,6 +25,7 @@
               {% if request.user.is_anonymous %}
               <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
               {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
               <li><a href="{% url 'log_out' %}">Logout</a></li>
               {% endif %}
           </ul>

--- a/public_officials/templates/public-officials/home.html
+++ b/public_officials/templates/public-officials/home.html
@@ -21,6 +21,11 @@
               <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
               <li><a href="{% url 'senator_index' %}">Senators</a></li>
               <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'logout' %}">Logout</a></li>
+              {% endif %}
               <li><a href="{% url 'about' %}">About</a></li>
           </ul>
         </div>

--- a/public_officials/templates/public-officials/home.html
+++ b/public_officials/templates/public-officials/home.html
@@ -21,12 +21,12 @@
               <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
               <li><a href="{% url 'senator_index' %}">Senators</a></li>
               <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
               {% if request.user.is_anonymous %}
               <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
               {% else %}
-              <li><a href="{% url 'logout' %}">Logout</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
               {% endif %}
-              <li><a href="{% url 'about' %}">About</a></li>
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/representatives/index.html
+++ b/public_officials/templates/public-officials/representatives/index.html
@@ -16,10 +16,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
-            <li><a href="{% url 'senator_index' %}">Senators</a></li>
-            <li><a href="{% url 'representative_index' %}">Representatives</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/senators/index.html
+++ b/public_officials/templates/public-officials/senators/index.html
@@ -16,10 +16,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
-            <li><a href="{% url 'senator_index' %}">Senators</a></li>
-            <li><a href="{% url 'representative_index' %}">Representatives</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/state.html
+++ b/public_officials/templates/public-officials/state.html
@@ -16,10 +16,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
-            <li><a href="{% url 'senator_index' %}">Senators</a></li>
-            <li><a href="{% url 'representative_index' %}">Representatives</a></li>
-            <li><a href="{% url 'about' %}">About</a></li>
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'user_show' %}">Profile</a></li>
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
           </ul>
         </div>
       </div>

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script type="text/javascript" src="/static/public_officials/bootstrap-3.3.7-dist/js/bootstrap.min.js"></script>
+    <link href="/static/public_officials/bootstrap-3.3.7-dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/public_officials/stylesheets/main.css" rel="stylesheet">
+    <title>Will Legislate For Money</title>
+  </head>
+  <body>
+    <nav class="navbar navbar-default">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="{% url 'home' %}">Home</a>
+        </div>
+
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          <ul class="nav navbar-nav navbar-right">
+              <li><a href="{% url 'bills_index' %}">Recent Bills</a></li>
+              <li><a href="{% url 'senator_index' %}">Senators</a></li>
+              <li><a href="{% url 'representative_index' %}">Representatives</a></li>
+              <li><a href="{% url 'about' %}">About</a></li>
+              {% if request.user.is_anonymous %}
+              <li><a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a></li>
+              {% else %}
+              <li><a href="{% url 'log_out' %}">Logout</a></li>
+              {% endif %}
+          </ul>
+        </div>
+      </div>
+    </nav>
+      <h2 class='text-center'>Welcome {{ request.user }}!!!</h2>
+  </body>
+</html>

--- a/public_officials/templates/registration/login.html
+++ b/public_officials/templates/registration/login.html
@@ -1,0 +1,12 @@
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Login</button>
+  </form>
+  <br>
+  <p><strong>-- OR --</strong></p>
+  <a href="{% url 'social:begin' 'twitter' %}">Login with Twitter</a><br>
+{% endblock %}

--- a/public_officials/views.py
+++ b/public_officials/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import logout
 from django.contrib.auth.decorators import *
 from django.shortcuts import render, redirect, render_to_response
 from django.http import HttpResponse, JsonResponse
@@ -68,7 +69,6 @@ def bills_index(request):
 def about(request):
     return render(request, 'public-officials/about.html')
 
-def logout(request):
-    django.contrib.auth.logout
-    states = Legislator.get_all_state_names()
-    return render(request, 'public-officials/home.html', {'states': states})
+def log_out(request):
+    logout(request)
+    return redirect('/')

--- a/public_officials/views.py
+++ b/public_officials/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import *
 from django.shortcuts import render, redirect, render_to_response
 from django.http import HttpResponse, JsonResponse
 from public_officials.services import *
@@ -66,3 +67,8 @@ def bills_index(request):
 
 def about(request):
     return render(request, 'public-officials/about.html')
+
+def logout(request):
+    django.contrib.auth.logout
+    states = Legislator.get_all_state_names()
+    return render(request, 'public-officials/home.html', {'states': states})

--- a/public_officials/views.py
+++ b/public_officials/views.py
@@ -72,3 +72,7 @@ def about(request):
 def log_out(request):
     logout(request)
     return redirect('/')
+
+@login_required
+def user_show(request):
+    return render(request, 'public-officials/user_show.html')

--- a/will_legislate_for_money/settings.py
+++ b/will_legislate_for_money/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'public_officials',
+    'social_django',
 ]
 
 MIDDLEWARE = [
@@ -48,6 +49,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'will_legislate_for_money.urls'
@@ -63,6 +65,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
         },
     },

--- a/will_legislate_for_money/settings.py
+++ b/will_legislate_for_money/settings.py
@@ -74,6 +74,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'will_legislate_for_money.wsgi.application'
 
+AUTHENTICATION_BACKENDS = (
+    'social_core.backends.twitter.TwitterOAuth',
+
+    'django.contrib.auth.backends.ModelBackend',
+)
 
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases

--- a/will_legislate_for_money/settings.py
+++ b/will_legislate_for_money/settings.py
@@ -1,3 +1,4 @@
+from will_legislate_for_money.secrets import *
 """
 Django settings for will_legislate_for_money project.
 
@@ -147,3 +148,5 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, '../static'))
+SOCIAL_AUTH_TWITTER_KEY = TWITTER_KEY
+SOCIAL_AUTH_TWITTER_SECRET = TWITTER_SECRET

--- a/will_legislate_for_money/urls.py
+++ b/will_legislate_for_money/urls.py
@@ -17,6 +17,8 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from public_officials import views as public_official_views
 
+from django.contrib.auth import views as auth_views
+
 urlpatterns = [
     url(r'^$', public_official_views.home_page, name="home"),
     url(r'^about/$', public_official_views.about, name="about"),
@@ -26,4 +28,7 @@ urlpatterns = [
     url(r'^recent-bills/$', public_official_views.bills_index, name="bills_index"),
     url(r'^legislators/', include('public_officials.urls')),
     url(r'^admin/', admin.site.urls),
+    url(r'^login/$', auth_views.login, name='login'),
+    url(r'^logout/$', auth_views.logout, name='logout'),
+    url(r'^oauth/', include('social_django.urls', namespace='social')),
 ]

--- a/will_legislate_for_money/urls.py
+++ b/will_legislate_for_money/urls.py
@@ -28,10 +28,9 @@ urlpatterns = [
     url(r'^recent-bills/$', public_official_views.bills_index, name="bills_index"),
     url(r'^legislators/', include('public_officials.urls')),
     url(r'^admin/', admin.site.urls),
-    url(r'^login/$', auth_views.login, name='login'),
     url(r'^logout/$', public_official_views.log_out, name="log_out"),
     url(r'^oauth/', include('social_django.urls', namespace='social')),
-    url(r'^accounts/profile/', public_official_views.home_page, name="home"),
+    url(r'^accounts/profile/', public_official_views.user_show, name="user_show"),
     url(r'^accounts/login/', auth_views.login, name='login'),
 ]
 

--- a/will_legislate_for_money/urls.py
+++ b/will_legislate_for_money/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     url(r'^legislators/', include('public_officials.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^login/$', auth_views.login, name='login'),
-    url(r'^logout/$', auth_views.logout, name='logout'),
+    url(r'^logout/$', public_official_views.log_out, name="log_out"),
     url(r'^oauth/', include('social_django.urls', namespace='social')),
     url(r'^accounts/profile/', public_official_views.home_page, name="home"),
     url(r'^accounts/login/', auth_views.login, name='login'),

--- a/will_legislate_for_money/urls.py
+++ b/will_legislate_for_money/urls.py
@@ -31,4 +31,11 @@ urlpatterns = [
     url(r'^login/$', auth_views.login, name='login'),
     url(r'^logout/$', auth_views.logout, name='logout'),
     url(r'^oauth/', include('social_django.urls', namespace='social')),
+    url(r'^accounts/profile/', public_official_views.home_page, name="home"),
+    url(r'^accounts/login/', auth_views.login, name='login'),
 ]
+
+LOGIN_URL = 'login'
+LOGOUT_URL = 'logout'
+SOCIAL_AUTH_LOGIN_REDIRECT_URL = 'home'
+SOCIAL_AUTH_LOGIN_URL = 'home'


### PR DESCRIPTION
Enables user authentication via Twitter OAuth. This is accomplished through the use of the social-auth-app-django package. Necessary routes have been added to the urls.py to accommodate appropriate redirection on log-in and log-out. The authenticated user will be directed on log-in to '/accounts/profile' where a welcome message is displayed with the users username. The nav-bar was modified such that the an unauthenticated user will always be presented with the option to 'Login with Twitter', and the authenticated user will see a link to log out or visit their profile.

Some concerns as code presently stands; we modified the navbar in each template. We're happy with it as is for the purpose of function but would like to DRY out the code figuring out how to use a partial for it.

We're up to date with the memcaching piece, but there are two failing tests on this branch with the following errors produced:
service_gets_sponsored_bills_for_one_legislator
    formatted_bills = bills.json()['results'][0]['bills']
KeyError: 'results'


test_service_gets_voting_history_for_one_legislator
   formatted_votes = votes.json()['results'][0]['votes']
KeyError: 'results'

Any feedback for these? @meyerhoferc