### PR TITLE
Add permission to legislator follow button

### DIFF
--- a/public_officials/functional_tests/test_public_officials.py
+++ b/public_officials/functional_tests/test_public_officials.py
@@ -47,11 +47,11 @@ class GuestUserTest(StaticLiveServerTestCase):
             self.browser.get(self.live_server_url + '/legislators/%d/' % legislator.id)
             name_text = self.browser.find_element_by_tag_name('h1').text
             status_text = self.browser.find_element_by_tag_name('h3').text
-            follow_button_text = self.browser.find_element_by_css_selector('.follow').text
+            follow_button_text = self.browser.find_element_by_css_selector('#follow-legislator').text
             bio_text = self.browser.find_element_by_css_selector('.profile').text
             stats_text = self.browser.find_element_by_css_selector('.stats').text
             self.assertIn("Diana DeGette", name_text)
-            self.assertIn("Follow", follow_button_text)
+            self.assertNotIn("Follow", follow_button_text)
             self.assertIn("Colorado Representative", status_text)
             self.assertIn("Term Start: January 03, 2017", stats_text)
             self.assertIn("Term End: January 03, 2019", stats_text)

--- a/public_officials/templates/public-officials/detail.html
+++ b/public_officials/templates/public-officials/detail.html
@@ -41,8 +41,10 @@
       <div class="profile col-md-4 col-md-offset-1 legislator" data-legislator-id="{{ legislator.cid }}" data-legislator-pid="{{ legislator.pid }}">
         <h1>{{ legislator.first_name }} {{ legislator.last_name }}</h1>
       </div>
-      <div class="col-md-1 col-md-offset-5">
+      <div class="col-md-1 col-md-offset-5" id="follow-legislator">
+        {% if request.user.is_authenticated %}
         <button class="follow btn">Follow</button>
+        {% endif %}
       </div>
     </div>
 


### PR DESCRIPTION
The follow button only displays if a user is logged in. The corresponding functional test reflects the new changes by asserting that it is not there since we haven't stubbed out logged in users yet. All tests passing.