### PR TITLE
User show style changes

### DIFF
--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -29,18 +29,8 @@ function changeHoverColor(){
 })
 }
 
-function modifyButtonMargins(){
-  $(".display-tweets, .unfollow-button").css({"margin-top": '10px', "margin-bottom": '10px'})
-}
-
-function modifyButtonColor(){
-  $(".display-tweets").css({'background-color': '#1DCAFF', 'font-size': '12pt', 'color': 'black'})
-  $(".unfollow-button").css({'font-size': '12pt','color': 'black' })
-}
 $(document).ready(function(){
   $('.display-tweets').on('click', displayTweets)
   $('.unfollow-button').on('click', unfollowLegislator)
   changeHoverColor()
-  modifyButtonMargins()
-  modifyButtonColor()
 });

--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -21,8 +21,16 @@ function removeLegislator(unfollowButton){
   unfollowButton.remove()
 }
 
+function changeHoverColor(){
+  $(".list-group-item").hover(function() {
+  $(this).css({"background-color": "#ADD8E6", "font-weight": "bold"})
+}).mouseout(function(){
+  $(this).css({"background-color": "white", "font-weight": "normal"})
+})
+}
+
 $(document).ready(function(){
   $('.display-tweets').on('click', displayTweets)
   $('.unfollow-button').on('click', unfollowLegislator)
-
+  changeHoverColor()
 });

--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -23,7 +23,7 @@ function removeLegislator(unfollowButton){
 
 function changeLegislatorHoverColor(){
   $(".list-group-item").hover(function() {
-  $(this).css({"background-color": "#ADD8E6", "font-weight": "bold"})
+  $(this).css({"background-color": "#ADD8E6", "font-weight": "bold", "color": 'black'})
 }).mouseout(function(){
   $(this).css({"background-color": "white", "font-weight": "normal"})
 })

--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -21,16 +21,25 @@ function removeLegislator(unfollowButton){
   unfollowButton.remove()
 }
 
-function changeHoverColor(){
+function changeLegislatorHoverColor(){
   $(".list-group-item").hover(function() {
   $(this).css({"background-color": "#ADD8E6", "font-weight": "bold"})
 }).mouseout(function(){
   $(this).css({"background-color": "white", "font-weight": "normal"})
 })
 }
-
+function makeNavBarAccessible(){
+  $('li>a').css({'color': 'black', 'font-size': '12pt'})
+  $('.navbar-brand').css('color', 'black')
+  $('li, .navbar-brand').hover(function(){
+    $(this).css({'background-color': "#ADD8E6", "font-weight": "bold"})
+  }).mouseout(function(){
+    $(this).css({'background-color': "#F8F8F8", "font-weight": "normal"})
+  })
+}
 $(document).ready(function(){
   $('.display-tweets').on('click', displayTweets)
   $('.unfollow-button').on('click', unfollowLegislator)
-  changeHoverColor()
+  changeLegislatorHoverColor()
+  makeNavBarAccessible()
 });

--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -2,7 +2,7 @@
 function displayTweets(){
   $('#tweet-box').html('')
   let twitterId = this.getAttribute('data-twitter-id')
-  let tweetLink = `<a class="twitter-timeline" data-width="450" href="https://twitter.com/${twitterId}">Tweets by ${twitterId}</a>`
+  let tweetLink = `<a class="twitter-timeline" data-width="700" href="https://twitter.com/${twitterId}">Tweets by ${twitterId}</a>`
   $('#tweet-box').append(`<script src="//platform.twitter.com/widgets.js" charset="utf-8"></script>`)
   $('#tweet-box').append(tweetLink)
 }

--- a/public_officials/static/public_officials/js/user_show.js
+++ b/public_officials/static/public_officials/js/user_show.js
@@ -29,8 +29,18 @@ function changeHoverColor(){
 })
 }
 
+function modifyButtonMargins(){
+  $(".display-tweets, .unfollow-button").css({"margin-top": '10px', "margin-bottom": '10px'})
+}
+
+function modifyButtonColor(){
+  $(".display-tweets").css({'background-color': '#1DCAFF', 'font-size': '12pt', 'color': 'black'})
+  $(".unfollow-button").css({'font-size': '12pt','color': 'black' })
+}
 $(document).ready(function(){
   $('.display-tweets').on('click', displayTweets)
   $('.unfollow-button').on('click', unfollowLegislator)
   changeHoverColor()
+  modifyButtonMargins()
+  modifyButtonColor()
 });

--- a/public_officials/static/public_officials/stylesheets/main.css
+++ b/public_officials/static/public_officials/stylesheets/main.css
@@ -119,3 +119,7 @@ button.follow {
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+.twitter-timeline {
+  margin-left: 55px;
+}

--- a/public_officials/static/public_officials/stylesheets/main.css
+++ b/public_officials/static/public_officials/stylesheets/main.css
@@ -103,3 +103,19 @@ button.follow {
   font-weight: bold;
   line-height: 1;
 }
+
+.btn.unfollow-button {
+  font-size: 12pt;
+  color: black;
+  background-color: #D9534F;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.btn.display-tweets {
+  font-size: 12pt;
+  color: black;
+  background-color: #1DCAFF;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/public_officials/static/public_officials/stylesheets/main.css
+++ b/public_officials/static/public_officials/stylesheets/main.css
@@ -121,5 +121,5 @@ button.follow {
 }
 
 .twitter-timeline {
-  margin-left: 55px;
+  margin-left: 50px;
 }

--- a/public_officials/static/public_officials/stylesheets/main.css
+++ b/public_officials/static/public_officials/stylesheets/main.css
@@ -111,6 +111,12 @@ button.follow {
   margin-top: 10px;
   margin-bottom: 10px;
 }
+.btn.unfollow-button:hover{
+  font-weight: bold;
+}
+.btn.display-tweets:hover{
+  font-weight: bold;
+}
 
 .btn.display-tweets {
   font-size: 12pt;

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -33,7 +33,7 @@
     </nav>
       <h2 class='text-center'>Welcome {{ request.user }}!!!</h2>
         <div class='list-group col-md-4' style='margin-left: 20px;'>
-          <h4 class='text-center'>Your Followed Representatives</h4>
+          <h4 class='text-center'>Your Followed Legislators</h4>
           {% for legislator in legislators %}
             <a class="list-group-item" href='/legislators/{{legislator.id}}'>
               {{ legislator.first_name }} {{legislator.last_name}} {{legislator.chamber.capitalize }} {{legislator.state}}-{{legislator.party}}

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -32,7 +32,7 @@
       </div>
     </nav>
       <h2 class='text-center'>Welcome {{ request.user }}!!!</h2>
-        <div class=' col-md-4 list-group' style='margin-left: 30px;'>
+        <div class=' col-md-4 list-group' style='margin-left: 50px;'>
           <h4 class='text-center'>Your Followed Legislators</h4>
           {% for legislator in legislators %}
             <a class="list-group-item" href='/legislators/{{legislator.id}}'>

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -32,7 +32,7 @@
       </div>
     </nav>
       <h2 class='text-center'>Welcome {{ request.user }}!!!</h2>
-        <div class='list-group col-md-4' style='margin-left: 20px;'>
+        <div class=' col-md-4 list-group' style='margin-left: 30px;'>
           <h4 class='text-center'>Your Followed Legislators</h4>
           {% for legislator in legislators %}
             <a class="list-group-item" href='/legislators/{{legislator.id}}'>
@@ -42,7 +42,7 @@
             <button style='float: right' class='btn unfollow-button' data-leg-id='{{legislator.id}}' data-user-id='{{request.user.id}}'>Unfollow {{legislator.first_name}}</button>
           {% endfor %}
         </div>
-        <div id='tweet-box'>
+        <div id='tweet-box' >
         </div>
   </body>
 </html>

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -38,8 +38,8 @@
             <a class="list-group-item" href='/legislators/{{legislator.id}}'>
               {{ legislator.first_name }} {{legislator.last_name}} {{legislator.chamber.capitalize }} {{legislator.state}}-{{legislator.party}}
             </a>
-            <button class='btn btn-info display-tweets' data-twitter-id='{{legislator.twitter_id}}'>Display Tweets from {{legislator.first_name}}</button>
-            <button style='float: right' class='btn btn-danger unfollow-button' data-leg-id='{{legislator.id}}' data-user-id='{{request.user.id}}'>Unfollow {{legislator.first_name}}</button>
+            <button class='btn display-tweets' data-twitter-id='{{legislator.twitter_id}}'>Display Tweets from {{legislator.first_name}}</button>
+            <button style='float: right' class='btn unfollow-button' data-leg-id='{{legislator.id}}' data-user-id='{{request.user.id}}'>Unfollow {{legislator.first_name}}</button>
           {% endfor %}
         </div>
         <div id='tweet-box'>

--- a/public_officials/templates/public-officials/user_show.html
+++ b/public_officials/templates/public-officials/user_show.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang='en'>
   <head>
     <meta charset="utf-8">
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
@@ -39,7 +39,7 @@
               {{ legislator.first_name }} {{legislator.last_name}} {{legislator.chamber.capitalize }} {{legislator.state}}-{{legislator.party}}
             </a>
             <button class='btn btn-info display-tweets' data-twitter-id='{{legislator.twitter_id}}'>Display Tweets from {{legislator.first_name}}</button>
-            <button style='float: right;' class='btn btn-danger unfollow-button' data-leg-id='{{legislator.id}}' data-user-id='{{request.user.id}}'>Unfollow {{legislator.first_name}}</button>
+            <button style='float: right' class='btn btn-danger unfollow-button' data-leg-id='{{legislator.id}}' data-user-id='{{request.user.id}}'>Unfollow {{legislator.first_name}}</button>
           {% endfor %}
         </div>
         <div id='tweet-box'>


### PR DESCRIPTION
Modifies user show page for display of only Twitter Timeline and followed legislators; arrangement of these objects has been changed to take up the width of the page while leaving margins on either side so it doesn't feel cramped. Changes 'Your Followed Representatives' to 'Your Followed Legislators' as heading. Adds JS functions to modify hover effects of Display Tweets and Unfollow buttons; the text will now be bolded on hover. Modifies CSS to resolve accessibility concerns as cited by the aXe Chrome extension. Coloring of the buttons and button text was modified to remove concerns. Navbar styling was modified to remove contrast concerns. On hover of a navbar link, the background-color will change to a shade of blue consistent with other hover functions and the text will become bolded. aXe currently reports that the page is free from accessibility concerns.  All page behavior is appropriate and as expected at this time.